### PR TITLE
fix: remove broken snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,8 @@ All notable changes to `hermod` will be documented in this file
 - Monitoring capabilities based on log messages
 - Function log() now adds timestamp to lines
 - Removed variables.sh in favor of .hermod config file
-- Introduced the snapshot module
+- Introduced the snapshot 
+
+## [1.0.1] - 2019-02-16
+### Fixed
+- Snapshot module will remove broken snapshots before proceeding

--- a/modules/snapshot.sh
+++ b/modules/snapshot.sh
@@ -74,7 +74,7 @@ snapshot_purge()
     cd "$HOME/.local/share/ark-core/$core_network/snapshots"
 
     # delete old snapshots
-    ls -t | tail -n +$snapshots_retain | xargs rm -r
+    ls -t | tail -n +$snapshots_retain | xargs --no-run-if-empty rm -r
 }
 
 snapshot_rollback()

--- a/modules/snapshot.sh
+++ b/modules/snapshot.sh
@@ -40,23 +40,33 @@ snapshot_dump()
 
     log "[SNAPSHOTS] Taking a fresh snapshot...";
 
-    yarn dump:$core_network &
+    yarn dump:$core_network 2>&1 | tee ${hermod_dir}/snapshot.log
 
-    log "[SNAPSHOTS] Done.";
+    if tail -n 5 ${hermod_dir}/snapshot.log | grep -q "Done in "; then 
+        log "[SNAPSHOTS] Done.";
+    else
+        snapshot_remove_most_recent
+        log "[SNAPSHOTS] Failed, see $hermod_dir/snapshot.log for details.";
+    fi
+    
 }
 
 snapshot_append()
 {
-    # get most recent snapshot
     most_recent_snapshot=$(ls -td * | head -1)
 
     cd "$core_path/packages/core-snapshots-cli"
 
     log "[SNAPSHOTS] Appending to snapshot: $most_recent_snapshot...";
 
-    yarn dump:$core_network --blocks $most_recent_snapshot
+    yarn dump:$core_network --blocks $most_recent_snapshot 2>&1 | tee ${hermod_dir}/snapshot.log
 
-    log "[SNAPSHOTS] Done.";
+    if tail -n 5 ${hermod_dir}/snapshot.log | grep -q "Done in "; then 
+        log "[SNAPSHOTS] Done.";
+    else
+        snapshot_remove_most_recent
+        log "[SNAPSHOTS] Failed, see $hermod_dir/snapshot.log for details.";
+    fi
 }
 
 snapshot_purge()
@@ -71,7 +81,6 @@ snapshot_rollback()
 {
     cd "$HOME/.local/share/ark-core/$core_network/snapshots"
 
-    # get most recent snapshot
     most_recent_snapshot=$(ls -td * | head -1)
 
     # trim the first 2 characters of the file name
@@ -94,4 +103,13 @@ snapshot_rollback()
     pm2 start all
 
     log "[SNAPSHOTS] Done.";
+}
+
+snapshot_remove_most_recent()
+{
+    cd "$HOME/.local/share/ark-core/$core_network/snapshots"
+
+    most_recent_snapshot=$(ls -td * | head -1)
+
+    rm -rf $most_recent_snapshot
 }


### PR DESCRIPTION
Removes snapshots that failed to be processed by `snapshot-cli`.