### PR TITLE
feat: add hermod share command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .hermod
 hermod.log
 data/snapshot.txt
-
 .DS_Store
+snapshot.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ hermod.log
 data/snapshot.txt
 .DS_Store
 snapshot.log
+snapshot-verify.log
+snapshots/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ All notable changes to `hermod` will be documented in this file
 ## [1.0.1] - 2019-02-16
 ### Fixed
 - Snapshot module will remove broken snapshots before proceeding
+
+## [1.0.2] - 2019-03-26
+### Added
+- Introduced `hermod share` to facilitate sharing snapshots with others

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ notification_drivers=(log slack discord)
 
 When rounds are saved on core, hermod will take snapshots, or append to the most recent one. It is enabled by default and it will keep the 5 most recent snapshots. Older snapshots are deleted. Make sure that you have enough storage space. 
 
+#### Sharing Snapshots
+
+If you need share a snapshot with someone, `hermod` facilitates it. By running `hermod share`, the command will archive the most recent snapshot, and host it on an URL that you can share with others. To be able to use this command, you must have at least one snapshot (you can run `hermod snapshot` to take one), and port `8080` must be open. 
+
 ### Notifications
 
 There are a couple of services that you can use to get notified by the script.
@@ -89,6 +93,7 @@ options:
     alias                     Create a bash alias for hermod.
     snapshot                  Take a new snapshot, or append to the most recent one.
     rollback                  Roll back to the most recent snapshot.
+    share                     Hosts the most recent snapshot on a temporary URL.
 ```
 
 ## Credits

--- a/modules/args.sh
+++ b/modules/args.sh
@@ -68,6 +68,11 @@ parse_args()
 
             exit 1
         ;;
+        share)
+            hermod_share
+
+            exit 1
+        ;;
         help|*)
             hermod_help
 

--- a/modules/commands.sh
+++ b/modules/commands.sh
@@ -114,6 +114,11 @@ hermod_rollback()
     snapshot_rollback
 }
 
+hermod_share()
+{
+    snapshot_share
+}
+
 hermod_help()
 {
     cat << EOF
@@ -135,5 +140,6 @@ options:
     alias                     Create a bash alias for hermod.
     snapshot                  Take a new snapshot, or append to the most recent one.
     rollback                  Roll back to the most recent snapshot.
+    share                     Hosts the most recent snapshot on a temporary URL.
 EOF
 }


### PR DESCRIPTION
Oftentimes we need to share a snapshot with someone else, `hermod share` facilitates it. By running `hermod share`, `hermod` will archive the most recent snapshot, and host it. In order to hide the server's IP, I used [`localtunnel`](https://github.com/localtunnel/localtunnel) to serve the snapshot under a proxied URL. 

The output looks like this:
```
munich@devnet:~/hermod$ hermod share
[SNAPSHOTS-SHARE] Verifying snapshot...
[2019-03-26 18:52:07.161] DEBUG: Data Directory => /home/munich/.local/share/ark-core/devnet
[2019-03-26 18:52:07.166] DEBUG: Config Directory => /home/munich/.config/ark-core/devnet
[2019-03-26 18:52:07.167] DEBUG: Cache Directory => /home/munich/.cache/ark-core/devnet
[2019-03-26 18:52:07.167] DEBUG: Log Directory => /home/munich/.local/state/ark-core/devnet
[2019-03-26 18:52:07.167] DEBUG: Temp Directory => /tmp/munich/ark-core/devnet
[2019-03-26 18:52:07.372] INFO : Snapshots: Database connected
[2019-03-26 18:52:07.377] INFO : Starting to verify snapshot file /home/munich/.local/share/ark-core/devnet/snapshots/1-1901806/blocks.lite
[2019-03-26 18:52:07.378] INFO : Starting to verify snapshot file /home/munich/.local/share/ark-core/devnet/snapshots/1-1901806/transactions.lite
[2019-03-26 18:52:20.446] INFO : Snapshot file /home/munich/.local/share/ark-core/devnet/snapshots/1-1901806/transactions.lite succesfully verified
[2019-03-26 18:52:29.962] INFO : Snapshot file /home/munich/.local/share/ark-core/devnet/snapshots/1-1901806/blocks.lite succesfully verified
[2019-03-26 18:52:29.963] INFO : Core is trying to gracefully shut down to avoid data corruption
[SNAPSHOTS-SHARE] Snapshot 1-1901806 is valid.
[SNAPSHOTS-SHARE] Starting webserver...
[SNAPSHOTS-SHARE] Starting tunnel...
[SNAPSHOTS-SHARE] Running on port 8080. When you're done, kill this command with CTRL + C to stop the webserver and tunnel.
npx: installed 55 in 2.565s
your url is: https://afraid-swan-3.localtunnel.me
```