### PR TITLE
fix: new log files

### DIFF
--- a/.hermod.example
+++ b/.hermod.example
@@ -27,6 +27,7 @@ monitor_notification_prefix=                               # adds a prefix on no
 
 core_network=mainnet                                       # values: devnet, mainnet, testnet
 core_path=$HOME/ark-core                                   # path to core's main directory (no trailing slash!)
+core_processes=2                                           # amount of core processes that you run (ark-relay + ark-forger = 2, ark-core = 1)
 core_log_path="$HOME/.local/state/ark-core/$core_network"  # path to where logs are stored (no trailing slash!)
 
 # -------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `hermod` will be documented in this file
 
+## [2.0.0] - 2019-04-24
+### Changed
+- Changed the log file names that are checked, as core 2.3 introduced new log filenames and structure. This is a breaking change as `hermod` will no longer work with versions that use the previous filenames.
+
 ## [1.2.0] - 2019-03-26
 ### Added
 - Introduced `hermod share` to facilitate sharing snapshots with others

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ notification_drivers=(log slack discord)
 
 ### Snapshots
 
-When rounds are saved on core, hermod will take snapshots, or append to the most recent one. It is enabled by default and it will keep the 5 most recent snapshots. Older snapshots are deleted. Make sure that you have enough storage space. 
+When rounds are saved on core, hermod will take snapshots, or append to the most recent one. It is enabled by default and it will keep the 5 most recent snapshots. Older snapshots are deleted. Make sure that you have enough storage space.
 
 #### Sharing Snapshots
 
-If you need share a snapshot with someone, `hermod` facilitates it. By running `hermod share`, the command will archive the most recent snapshot, and host it on an URL that you can share with others. To be able to use this command, you must have at least one snapshot (you can run `hermod snapshot` to take one), and port `8080` must be open. 
+If you need share a snapshot with someone, `hermod` facilitates it. By running `hermod share`, the command will archive the most recent snapshot, and host it on an URL that you can share with others. To be able to use this command, you must have at least one snapshot (you can run `hermod snapshot` to take one), and port `8080` must be open.
 
 ### Notifications
 
@@ -95,6 +95,14 @@ options:
     rollback                  Roll back to the most recent snapshot.
     share                     Hosts the most recent snapshot on a temporary URL.
 ```
+
+## Upgrading
+
+When upgrading from v1.x.x to v2.x.x, you should make the following changes:
+
+- In your `.hermod` configuration file, you should add `core_processes=<number>`, where `<number>` is either `2` (if you run `ark-relay` and `ark-forger` as separate processes, or `1` if you run the combined `ark-core` process). You can see an example of this in the [`.hermod.example`](https://github.com/ItsANameToo/hermod/blob/master/.hermod.example#L30) file.
+
+Make sure to restart `hermod` to have the changes take effect!
 
 ## Credits
 

--- a/modules/config.sh
+++ b/modules/config.sh
@@ -27,12 +27,20 @@ check_configuration()
 {
 
     log_files=("${core_log_path}/*.log")
-    if [ ! -e ${log_files[0]} ]; then 
+    if [ ! -e ${log_files[0]} ]; then
         abort 1 "log file in specified folder [$core_log_path] does not exist"
     fi
 
     if [[ $core_network != 'mainnet' && $core_network != 'devnet' ]]; then
         abort 1 "core_network [$core_network] is invalid."
+    fi
+
+    if [ -z "$core_processes" ]; then
+        abort 1 "core_processes should not be empty."
+    fi
+
+    if (($core_processes != 1 && $core_processes != 2)); then
+        abort 1 "core_processes [$core_processes] has to be set to 1 or 2."
     fi
 
     if (($monitor_lines <= 0)); then

--- a/modules/monitor.sh
+++ b/modules/monitor.sh
@@ -16,7 +16,7 @@ monitor()
 
     last_line='';
     last_line_count=0;
-    if [["$core_processes" -eq 1]]
+    if (("$core_processes" == 1))
     then
         forger_log="${core_log_path}/*core-current.log"
         relay_log="${core_log_path}/*core-current.log"

--- a/modules/monitor.sh
+++ b/modules/monitor.sh
@@ -16,7 +16,14 @@ monitor()
 
     last_line='';
     last_line_count=0;
-    log_file="${core_log_path}/*.log"
+    if [["$core_processes" -eq 1]]
+    then
+        forger_log="${core_log_path}/*core-current.log"
+        relay_log="${core_log_path}/*core-current.log"
+    else
+        forger_log="${core_log_path}/*forger-current.log"
+        relay_log="${core_log_path}/*relay-current.log"
+    fi
 
     while true; do
 
@@ -55,18 +62,18 @@ monitor()
 
 monitor_quorum()
 {
-    if tail -n $monitor_lines $log_file | grep -q "Fork 6 - Not enough quorum to forge next block"; then
+    if tail -n $monitor_lines $forger_log | grep -q "Fork 6 - Not enough quorum to forge next block"; then
         notify "[NO QUORUM] - Fork 6; Not enough quorum to forge";
     fi
 
-    if tail -n $monitor_lines $log_file | grep -q "Network reach is not sufficient to get quorum"; then
+    if tail -n $monitor_lines $forger_log | grep -q "Network reach is not sufficient to get quorum"; then
         notify "[NO QUORUM] - Insufficient network reach for quorum";
     fi
 }
 
 monitor_blocks()
 {
-    if tail -n $monitor_lines $log_file | grep -q "Delegate $delegate_username ($delegate_public_key) just missed a block"; then
+    if tail -n $monitor_lines $relay_log | grep -q "Delegate $delegate_username ($delegate_public_key) just missed a block"; then
         notify "[MISSED BLOCK] - You have missed a block this round";
 
         sleep $monitor_sleep_after_notif
@@ -75,20 +82,20 @@ monitor_blocks()
 
 monitor_disregarded()
 {
-    if tail -n $monitor_lines $log_file | grep -q "disregarded because already in blockchain"; then
+    if tail -n $monitor_lines $relay_log | grep -q "disregarded because already in blockchain"; then
         notify "[BLOCK DISREGARDED] - Block disregarded because already in blockchain";
     fi
 }
 
 monitor_synced()
 {
-    if tail -n $monitor_lines $log_file | grep -q "NOTSYNCED"; then
+    if tail -n $monitor_lines $relay_log | grep -q "NOTSYNCED"; then
         notify "[OUT OF SYNC] - Node out of sync";
 
         sleep $monitor_sleep_after_notif
     fi
 
-    if tail -n $monitor_lines $log_file | grep -q "Tried to sync 5 times to different nodes, looks like the network is missing blocks"; then
+    if tail -n $monitor_lines $relay_log | grep -q "Tried to sync 5 times to different nodes, looks like the network is missing blocks"; then
         notify "[OUT OF SYNC] - Tried syncing to different nodes but failed";
 
         sleep $monitor_sleep_after_notif
@@ -97,7 +104,7 @@ monitor_synced()
 
 monitor_stopped()
 {
-    if tail -n $monitor_lines $log_file | grep -q -e "Disconnecting" -e "Stopping" -e "STOP" -e "The blockchain has been stopped"; then
+    if tail -n $monitor_lines $relay_log | grep -q -e "Disconnecting" -e "Stopping" -e "STOP" -e "The blockchain has been stopped"; then
         notify "[STOPPING] - Node stopping / stopped";
 
         sleep $monitor_sleep_after_notif
@@ -106,7 +113,7 @@ monitor_stopped()
 
 monitor_started()
 {
-    if tail -n $monitor_lines $log_file | grep -q -e "Starting Blockchain" -e "Verifying database integrity" -e "START"; then
+    if tail -n $monitor_lines $relay_log | grep -q -e "Starting Blockchain" -e "Verifying database integrity" -e "START"; then
         notify "[STARTING] - Node starting / started";
 
         sleep $monitor_sleep_after_notif
@@ -115,7 +122,7 @@ monitor_started()
 
 monitor_relay()
 {
-    if tail -n $monitor_lines $log_file | grep -q "didn't respond to the forger. Trying another host"; then 
+    if tail -n $monitor_lines $forger_log | grep -q "didn't respond to the forger. Trying another host"; then
         notify "[RELAY] - Relay did not respond to the forger";
 
         sleep $monitor_sleep_after_notif
@@ -124,7 +131,7 @@ monitor_relay()
 
 monitor_double_forgery()
 {
-    if tail -n $monitor_lines $log_file | grep -q "Possible double forging delegate"; then 
+    if tail -n $monitor_lines $relay_log | grep -q "Possible double forging delegate"; then
         notify "[DOUBLE FORGERY] - Possible double forgery - Network might be unstable";
 
         sleep $monitor_sleep_after_notif
@@ -133,7 +140,7 @@ monitor_double_forgery()
 
 monitor_network_rollback()
 {
-    if tail -n $monitor_lines $log_file | grep -q "is too low. Going to rollback"; then 
+    if tail -n $monitor_lines $relay_log | grep -q "is too low. Going to rollback"; then
         notify "[ROLLBACK] - Node is rolling back - Network might be unstable";
 
         sleep $monitor_sleep_after_notif
@@ -142,7 +149,7 @@ monitor_network_rollback()
 
 monitor_fork()
 {
-    if tail -n $monitor_lines $log_file | grep -q "event 'FORK':"; then 
+    if tail -n $monitor_lines $relay_log | grep -q "event 'FORK':"; then
         notify "[FORK] - Node has forked - Network might be unstable";
 
         sleep $monitor_sleep_after_notif
@@ -151,21 +158,21 @@ monitor_fork()
 
 monitor_round_saved()
 {
-    if tail -n $monitor_lines $log_file | grep -q "Saving round"; then
+    if tail -n $monitor_lines $relay_log | grep -q "Saving round"; then
 
         if [[ $snapshots_enabled == "true" ]];
         then
             # run snapshot() function when rounds are saved
             snapshot
         fi
-        
+
         sleep $monitor_sleep_after_notif
     fi
 }
 
 monitor_last_line()
 {
-    new_last_line=$( tail -n 1 $log_file );
+    new_last_line=$( tail -n 1 $relay_log );
 
     if [[ "$new_last_line" = "$last_line" ]]; then
         last_line_count=$(($last_line_count + 1))


### PR DESCRIPTION
Adds a check for the new log files, since they are now split into `ark-forger-current` + `ark-relay-current`, or `ark-core-current`. Added an extra var to the `.hermod` file to specify which setup a delegate uses.