### PR TITLE
fix: check successful snapshot

### DIFF
--- a/modules/snapshot.sh
+++ b/modules/snapshot.sh
@@ -44,7 +44,7 @@ snapshot_dump()
 
     doneCount=$(tail -n 6 ${hermod_dir}/snapshot.log | grep -c "done")
 
-    if [ $doneCount -eq 2 ]; then
+    if [ $doneCount -eq 3 ]; then
         log "[SNAPSHOTS] Done.";
     else
         snapshot_remove_most_recent
@@ -64,7 +64,7 @@ snapshot_append()
 
     doneCount=$(tail -n 6 ${hermod_dir}/snapshot.log | grep -c "done")
 
-    if [ $doneCount -eq 2 ]; then
+    if [ $doneCount -eq 3 ]; then
         log "[SNAPSHOTS] Done.";
     else
         snapshot_remove_most_recent


### PR DESCRIPTION
`doneCount` should be `3`, not `2`:
```
[2019-06-25 22:09:26.949] DEBUG: Connected to database.
[2019-06-25 22:09:27.268] INFO : Starting to export table blocks to folder 1-8784903, append:false, skipCompression: false
[2019-06-25 22:17:12.326] INFO : Snapshot: blocks done. ==> Total rows processed: 8784903, duration: 465053 ms
[2019-06-25 22:17:12.332] INFO : Starting to export table transactions to folder 1-8784903, append:false, skipCompression: false
[2019-06-25 22:19:26.519] INFO : Snapshot: transactions done. ==> Total rows processed: 2621842, duration: 134175 ms
[2019-06-25 22:19:26.528] INFO : Starting to export table rounds to folder 1-8784903, append:false, skipCompression: false
[2019-06-25 22:22:04.366] INFO : Snapshot: rounds done. ==> Total rows processed: 8784903, duration: 157834 ms
[2019-06-25 22:22:04.380] INFO : Core is trying to gracefully shut down to avoid data corruption
```